### PR TITLE
Allow sftp connectors to use a private key set in the config

### DIFF
--- a/common/sftp.go
+++ b/common/sftp.go
@@ -127,6 +127,11 @@ func ensureMaster(endpoint *url.URL, params map[string]string) (string, error) {
 		}
 	}
 
+	// add the private key to the agent if necessary
+	if err := setupPrivateKey(params); err != nil {
+		return "", fmt.Errorf("failed to set private key: %w", err)
+	}
+
 	// start master
 	{
 		args, err := commonArgs()
@@ -179,11 +184,6 @@ func Connect(endpoint *url.URL, params map[string]string) (*sftp.Client, error) 
 	host := endpoint.Hostname()
 	if host == "" {
 		return nil, fmt.Errorf("missing hostname in endpoint: %q", endpoint.String())
-	}
-
-	// add the private key to the agent if necessary
-	if err := setupPrivateKey(params); err != nil {
-		return nil, fmt.Errorf("failed to set private key: %w", err)
 	}
 
 	// ensure the master exists (idempotent) and get the control socket path.


### PR DESCRIPTION
This requires a running ssh-agent.  The private key will be added to the agent prior to establishing the connection, with a short ttl to avoid leaving the key in the agent.

It introduces three new parameters:

- ssh_private_key: The private key to use. It must not have a passphrase.
- ssh_private_key_ttl:  How long the key lives in the agent. Defaults to 5s.
- ssh_auth_sock: Path to an alternate ssh-agent socket.